### PR TITLE
Get rid of unecessray 512byte fullpath bufgfer

### DIFF
--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -14,7 +14,7 @@ int is_rom_file(char *filename);
 int is_valid_file(char *filename);
 int read_directory(char *path, SCREEN_ENTRY *dst);
 void load_file(char *filename);
-void load_file_by_id(unsigned int id, char *path, char *fullpath);
+void load_file_by_id(unsigned int id, char *path);
 void filelist(SCREEN_ENTRY *en, int da, int a, int num);
 
 #endif

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -226,7 +226,7 @@ void load_file(char *filename) {
    printf("load_file: size: %ld bytes\n", cart.len*2);
 }
 
-void load_file_by_id(unsigned int id, char *path, char *fullpath) {
+void load_file_by_id(unsigned int id, char *path) {
 
    unsigned int i = 0;
    vfs_dir_t *dir;
@@ -252,12 +252,13 @@ void load_file_by_id(unsigned int id, char *path, char *fullpath) {
             if (!is_valid_file(ent.name))
                continue;
 
-         sprintf(fullpath, "%s/%s", path, ent.name);
-
          if (i++ == id) {
+            strcat(path, "/");
+            strcat(path, ent.name);
+
             vfs_closedir(dir);
-            printf("load_file_by_id: id %d, opening %s\n", id, fullpath);
-            load_file(fullpath); 
+            printf("load_file_by_id: id %d, opening %s\n", id, path);
+            load_file(path); 
             return;
          }
       }

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -49,7 +49,6 @@ extern struct mapHole holes[NSLOTS];
 extern struct memHack hacks[MAX_HACKS_NUM];
 
 char curPath[512] = "";
-char fullpath[512] = "";
 
 #if CONFIG_FLASH_FAT_STORAGE
 int volumeId = 0;    // default flash storage
@@ -92,11 +91,11 @@ int LoadGame(int entry_num) {
    }
 #endif
 
-   load_file_by_id(screen_entries[entry_num].id, curPath, fullpath);
+   load_file_by_id(screen_entries[entry_num].id, curPath);
 
    // ROM file has internal cfg info
-   if(!is_rom_file(fullpath))
-      load_cfg(fullpath);
+   if(!is_rom_file(curPath))
+      load_cfg(curPath);
 
    for (int i=0; i<getHacksNum(); i++) {
       uint32_t romaddr;


### PR DESCRIPTION
Get rid of unecessray 512byte fullpath buffer
Also removes time waste in copying string in while loop when only one copy was required at exit. 